### PR TITLE
Speed up fetch_array()

### DIFF
--- a/java/src/ServerThread.java
+++ b/java/src/ServerThread.java
@@ -43,7 +43,7 @@ public class ServerThread extends Thread {
         this.socket.setSoLinger(false, 0);
         
         this.in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-        this.out = new PrintWriter(socket.getOutputStream(), true);
+        this.out = new PrintWriter(socket.getOutputStream(), false);
         this.serverCommands = new ServerCommands(this);
     }
     
@@ -77,6 +77,7 @@ public class ServerThread extends Thread {
                     
                     break;
                 }
+                out.flush();
             }
             
             serverCommands.close();


### PR DESCRIPTION
Avoid delays caused by unnecessary auto-flushing halfway through
a response (e.g. a retrieved record) being sent to PHP.
Explicitly flushing at the end of the response is enough to ensure
that all data makes it to PHP.
The result is a retrieval speed increase of 30 to over 100 times.